### PR TITLE
tests: substrate-test-runtime is broken by  custom pallet-balance Gen…

### DIFF
--- a/substrate/test-utils/runtime/src/genesismap.rs
+++ b/substrate/test-utils/runtime/src/genesismap.rs
@@ -130,7 +130,11 @@ impl GenesisStorageBuilder {
 				authorities: authorities_sr25519.clone(),
 				..Default::default()
 			},
-			balances: pallet_balances::GenesisConfig { balances: self.balances.clone() },
+			balances: pallet_balances::GenesisConfig { total_issuance: self.balances.clone().into_iter()
+				.map((|(_p1, a)| a))
+				.reduce(|a, b| a + b)
+				.expect("Sum of balances must not overflow u64")
+			},
 		}
 	}
 


### PR DESCRIPTION
The `balances` field no more exists in `pallet_balances::GenesisConfig`, we have a `total_issuance` instead. I need it to add a unit test in https://git.duniter.org/nodes/rust/duniter-v2s/-/merge_requests/316 